### PR TITLE
Add SaveOptions to softDelete, for supporting skip validation case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,15 @@
         "@types/node": "*"
       }
     },
+    "@types/mongoose": {
+      "version": "5.11.97",
+      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.11.97.tgz",
+      "integrity": "sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==",
+      "dev": true,
+      "requires": {
+        "mongoose": "*"
+      }
+    },
     "@types/node": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.0.tgz",
@@ -1082,6 +1091,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+    },
+    "typescript": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,9 @@
   "dependencies": {
     "mongoose": "^5.12.5",
     "readme-md-generator": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/mongoose": "^5.10.5",
+    "typescript": "^4.2.3"
   }
 }

--- a/src/soft-delete-model.ts
+++ b/src/soft-delete-model.ts
@@ -1,8 +1,8 @@
-import {Document} from "mongoose";
+import {Document, SaveOptions} from "mongoose";
 import * as mongoose from "mongoose";
 
 export interface SoftDeleteModel<T extends Document> extends mongoose.Model<T> {
   findDeleted(): T[];
   restore(query: Record<string, any>): { restored: number };
-  softDelete(query: Record<string, any>): { deleted: number };
+  softDelete(query: Record<string, any>, options?: SaveOptions): { deleted: number };
 }

--- a/src/soft-delete-plugin.ts
+++ b/src/soft-delete-plugin.ts
@@ -1,4 +1,4 @@
-import mongoose, { CallbackError } from 'mongoose';
+import mongoose, { CallbackError, SaveOptions } from 'mongoose';
 
 export const softDeletePlugin = (schema: mongoose.Schema) => {
   schema.add({
@@ -62,7 +62,7 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
     return {restored};
   });
 
-  schema.static('softDelete', async function (query) {
+  schema.static('softDelete', async function (query, options?: SaveOptions) {
     const templates = await this.find(query);
     if (!templates) {
       return Error('Element not found');
@@ -73,7 +73,7 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
         template.$isDeleted(true);
         template.isDeleted = true;
         template.deletedAt = new Date();
-        await template.save().then(() => deleted++).catch((e: mongoose.Error) => { throw new Error(e.name + ' ' + e.message)});
+        await template.save(options).then(() => deleted++).catch((e: mongoose.Error) => { throw new Error(e.name + ' ' + e.message)});
       }
     }
     return {deleted};


### PR DESCRIPTION
Hi author,

I changed the schema of my collection then called the `softDelete` function. However, the save failed due to failed validation.

I thought it makes sense to pass the `{ validateBeforeSave: false }` to `softDelete` function when needed.

Also, I added the `devDependencies` section in the `package.json` to list the packages we need in development.

Please let me know if you have any concerns about this PR, thank you!