### PR TITLE
add return type promise for async functions

### DIFF
--- a/src/soft-delete-model.ts
+++ b/src/soft-delete-model.ts
@@ -2,7 +2,7 @@ import {Document, SaveOptions} from "mongoose";
 import * as mongoose from "mongoose";
 
 export interface SoftDeleteModel<T extends Document> extends mongoose.Model<T> {
-  findDeleted(): T[];
-  restore(query: Record<string, any>): { restored: number };
-  softDelete(query: Record<string, any>, options?: SaveOptions): { deleted: number };
+  findDeleted(): Promise<T[]>;
+  restore(query: Record<string, any>): Promise<{ restored: number }>;
+  softDelete(query: Record<string, any>, options?: SaveOptions): Promise<{ deleted: number }>;
 }


### PR DESCRIPTION
Like `findDeleted`, `restore` and `softDelete` are asynchronous functions, I added Promise as return type of they.
Now we can use then/catch/finally, without typescript being complaining

Error
```
Property 'then' does not exist on type '{ deleted: number; }'.ts(2339)
```
![image](https://user-images.githubusercontent.com/33585141/151591736-4ab28609-30de-48c4-9218-4d1e4a0a7953.png)


