### PR TITLE
feat(soft-delete) support countDocuments to filter out deleted document by default

### DIFF
--- a/src/soft-delete-plugin.ts
+++ b/src/soft-delete-plugin.ts
@@ -26,13 +26,23 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
 
   // @ts-ignore
   schema.pre('count',
-      async function (this, next: (err?: CallbackError) => void) {
-        if (this.getFilter().isDeleted === true) {
-          return next();
-        }
-        this.setQuery({ ...this.getFilter(), isDeleted: false });
-        next();
-      },)
+    async function (this, next: (err?: CallbackError) => void) {
+      if (this.getFilter().isDeleted === true) {
+        return next();
+      }
+      this.setQuery({ ...this.getFilter(), isDeleted: false });
+      next();
+    })
+
+  // @ts-ignore
+  schema.pre('countDocuments',
+    async function (this, next: (err?: CallbackError) => void) {
+      if (this.getFilter().isDeleted === true) {
+        return next();
+      }
+      this.setQuery({ ...this.getFilter(), isDeleted: false });
+      next();
+    })
 
   schema.static('findDeleted', async function () {
     return this.find({ isDeleted: true });
@@ -56,10 +66,10 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
         deletedTemplate.$isDeleted(false);
         deletedTemplate.isDeleted = false;
         deletedTemplate.deletedAt = null;
-        await deletedTemplate.save().then(() => restored ++).catch((e: mongoose.Error) => { throw new Error(e.name + ' ' + e.message)});
+        await deletedTemplate.save().then(() => restored++).catch((e: mongoose.Error) => { throw new Error(e.name + ' ' + e.message) });
       }
     }
-    return {restored};
+    return { restored };
   });
 
   schema.static('softDelete', async function (query, options?: SaveOptions) {
@@ -73,10 +83,10 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
         template.$isDeleted(true);
         template.isDeleted = true;
         template.deletedAt = new Date();
-        await template.save(options).then(() => deleted++).catch((e: mongoose.Error) => { throw new Error(e.name + ' ' + e.message)});
+        await template.save(options).then(() => deleted++).catch((e: mongoose.Error) => { throw new Error(e.name + ' ' + e.message) });
       }
     }
-    return {deleted};
+    return { deleted };
   });
 };
 


### PR DESCRIPTION
This PR supports `countDocuments` to filter out the soft deleted documents.

This functionality was requested by https://github.com/nour-karoui/mongoose-soft-delete/issues/10

I tested this change with the following script

```typescript
import mongoose from "mongoose";
import { softDeletePlugin, SoftDeleteModel } from 'soft-delete-plugin-mongoose';
const Schema = mongoose.Schema;

mongoose.connect('mongodb://localhost:27017/test');

const f = async () => {
    const TestSchema = new Schema({
        name: String,
        lastName: String
    });

    interface Test extends mongoose.Document {
        name: string;
        lastName: string;
    }

    TestSchema.plugin(softDeletePlugin);
    const testModel = mongoose.model<Test, SoftDeleteModel<Test>>('Test', TestSchema);

    const test = await new testModel({ name: 'hello', lastName: "world" });
    await test.save();

    await testModel.softDelete({ _id: test.id });

    const countDocuments = await testModel.countDocuments();
    console.log(countDocuments); // 0

    const count = await testModel.count();
    console.log(count); // 0
}
f();


```