### PR TITLE
Show old documents that do not have the isDeleted field

### DIFF
--- a/src/soft-delete-plugin.ts
+++ b/src/soft-delete-plugin.ts
@@ -19,7 +19,7 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
       if (this.getFilter().isDeleted === true) {
         return next();
       }
-      this.setQuery({ ...this.getFilter(), isDeleted: false });
+      this.setQuery({ ...this.getFilter(), $or:[{ isDeleted: false }, { isDeleted: null }] });
       next();
     },
   );
@@ -30,7 +30,7 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
       if (this.getFilter().isDeleted === true) {
         return next();
       }
-      this.setQuery({ ...this.getFilter(), isDeleted: false });
+      this.setQuery({ ...this.getFilter(), $or:[{ isDeleted: false }, { isDeleted: null }] });
       next();
     })
 
@@ -40,7 +40,7 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
       if (this.getFilter().isDeleted === true) {
         return next();
       }
-      this.setQuery({ ...this.getFilter(), isDeleted: false });
+      this.setQuery({ ...this.getFilter(), $or:[{ isDeleted: false }, { isDeleted: null }] });
       next();
     })
 


### PR DESCRIPTION
The plugin selects the documents which have the `isDeleted` field set to `false`. What if the database already has some documents that don't have the `isDeleted` field. They were created before adding the plugin. They haven't been deleted but they won't get returned.
This commit should select document that have `isDeleted` set to `false` or `null`