### PR TITLE
Minor fixes

### DIFF
--- a/src/soft-delete-model.ts
+++ b/src/soft-delete-model.ts
@@ -1,8 +1,34 @@
-import {Document, SaveOptions} from "mongoose";
+import { Document, SaveOptions } from "mongoose";
 import * as mongoose from "mongoose";
+
+export interface SoftDelete {
+  isDeleted: boolean;
+  deletedAt: Date | null;
+}
+
+export type SoftDeleteDocument = SoftDelete & Document;
 
 export interface SoftDeleteModel<T extends Document> extends mongoose.Model<T> {
   findDeleted(): Promise<T[]>;
-  restore(query: Record<string, any>): Promise<{ restored: number }>;
-  softDelete(query: Record<string, any>, options?: SaveOptions): Promise<{ deleted: number }>;
+
+  /**
+   * Finds the documents that matches the given query and restore them if `isDeleted` was set to true
+  */
+  restore(query: mongoose.FilterQuery<T>, orFail?: (e: Error) => unknown): Promise<{ restored: number }>;
+
+  /**
+   * Finds the document with the given ID and restores it if `isDeleted` was true
+   */
+  restoreById(id: string | mongoose.Types.ObjectId, orFail?: (e: Error) => unknown): Promise<void>;
+
+  /**
+   * Finds the documents with the given query and update the "isDeleted" & "deletedAt" properties
+   * If no document is found it will return `{ deleted: 0 }`
+  */
+  softDelete(query: mongoose.FilterQuery<T>, orFail?: (e: Error) => unknown): Promise<{ deleted: number }>;
+
+  /**
+   * Finds one document with the given id and udpate if one exists and it has not been deleted yet
+   */
+  softDeleteById(id: string | mongoose.Types.ObjectId, orFail?: (e: Error) => unknown): Promise<void>;
 }

--- a/src/soft-delete-plugin.ts
+++ b/src/soft-delete-plugin.ts
@@ -76,8 +76,6 @@ export function softDeletePlugin<T extends mongoose.Schema>(schema: T) {
       ...query,
     };
 
-    console.log(queryFilter)
-
     const { modifiedCount } = await this.updateMany(queryFilter, {
       $set: {
         isDeleted: true,


### PR DESCRIPTION
### Basic changes
- Added comments for better documentation of the SoftDeleteModel interface
- Added `softDeleteById` and `restoreById` for easier manipulation of single documents
- Replaced `Record<...>` with `mongoose.FilterQuery<...>` for better self code documentation and linting
- Errors should be handled by the callee, which is why I have added an optional `onFail` parameter so that the callee can decide how to handle errors.

### Removed find and save

The previous code would use a query to find all documents that matches the given query and loop through each document, either delete/restore them and call `save`, this operation can be slow specially when running a query against many documents. For better performance and code readability I have added a simple `updateMany` for both the `restore` and `softDelete` methods, the return value will still be the number of `modifiedDocuments` by the query.

#### Exec

The previous code would not call `exec` when building a query a rellying entiry on the async/await which worked, but for safety reasons it's best to call `exec` when we actually intend to run the query against the database.

### Context

These changes have been made to improve performance, code readability, and maintainability.