### PR TITLE
chore: handle missing query method hooks

### DIFF
--- a/src/soft-delete-plugin.ts
+++ b/src/soft-delete-plugin.ts
@@ -1,4 +1,15 @@
-import mongoose, { CallbackError, SaveOptions } from 'mongoose';
+import mongoose, { CallbackError, MongooseQueryMiddleware, SaveOptions } from 'mongoose';
+
+const QUERY_HOOK_METHODS: MongooseQueryMiddleware[] = [
+  'find',
+  'findOne',
+  'count',
+  'countDocuments',
+  'updateMany',
+  'updateOne',
+  'findOneAndUpdate',
+  'distinct',
+];
 
 export const softDeletePlugin = (schema: mongoose.Schema) => {
   schema.add({
@@ -14,7 +25,7 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
   });
 
   // @ts-ignore
-  schema.pre('find',
+  schema.pre(QUERY_HOOK_METHODS,
     async function (this, next: (err?: CallbackError) => void) {
       if (this.getFilter().isDeleted === true) {
         return next();
@@ -23,26 +34,6 @@ export const softDeletePlugin = (schema: mongoose.Schema) => {
       next();
     },
   );
-
-  // @ts-ignore
-  schema.pre('count',
-    async function (this, next: (err?: CallbackError) => void) {
-      if (this.getFilter().isDeleted === true) {
-        return next();
-      }
-      this.setQuery({ ...this.getFilter(), isDeleted: { $ne: true } });
-      next();
-    })
-
-  // @ts-ignore
-  schema.pre('countDocuments',
-    async function (this, next: (err?: CallbackError) => void) {
-      if (this.getFilter().isDeleted === true) {
-        return next();
-      }
-      this.setQuery({ ...this.getFilter(), isDeleted: { $ne: true } });
-      next();
-    })
 
   schema.static('findDeleted', async function () {
     return this.find({ isDeleted: true });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -39,6 +39,23 @@ describe('soft delete plugin', () => {
     // get this user after we performed soft delete
     const userAfterDelete = await userModel.find({ _id: user._id });
     expect(userAfterDelete?.length).toBe(0);
+    
+    const usersCount = await userModel.countDocuments();
+    expect(usersCount).toBe(0);
+
+    //soft deleted documents should not be updated by updateOne
+    const updatedUser = await userModel.updateOne({ _id: user._id }, { $set: { name: 'james' } });
+    expect(updatedUser.modifiedCount).toBe(0);
+
+    //soft deleted documents should not be updated by updateMany
+    const updatedUsers = await userModel.updateMany({ _id: user._id }, { $set: { name: 'james2' } });
+    expect(updatedUsers.modifiedCount).toBe(0);
+
+    const allUserIds = await userModel.distinct('_id');
+    expect(allUserIds.length).toBe(0);
+
+    const allUserIdsWithDeleted = await userModel.distinct('_id', { isDeleted: true });
+    expect(allUserIdsWithDeleted.length).toBe(1);
   });
 
   test('restore should be successed', async () => {


### PR DESCRIPTION
Some Mongoose queries are not respect the soft deleted records, which can cause run time issues, methods like:

1. `findOne`
2. `updateMany`
3. `updateOne`
4. `findOneAndUpdate`
5. `distinct`

all supported now with test coverage
